### PR TITLE
Change 'stringly typed' to 'strongly typed' in the index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
                   </p>
                   <p class="card-text">
                     Our async story is further enhanced by <a href="https://hyper.rs" alt="Hyper website">Hyper</a>,
-                    a fast server that provides an elegant layer over stringly typed HTTP.
+                    a fast server that provides an elegant layer over strongly typed HTTP.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
I discovered Gotham [on reddit](https://www.reddit.com/r/rust/comments/6t07dv/announcing_gotham/), and while reading over your site I noticed the phrase `over stringly typed HTTP`. I believe this should be `over strongly typed HTTP`, although `over stringently typed HTTP` would also make sense.