### PR TITLE
Update Gotham URLs to point at the main project

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,10 +330,10 @@ Listening on http://127.0.0.1:7878
                       <a href="https://github.com/gotham-rs/gotham" alt="Gotham framework on GitHub">Gotham Framework</a>
                     </li>
                     <li>
-                      <a href="https://github.com/gotham-rs/example-app" alt="Example application of GitHub">Example App</a>
+                      <a href="https://github.com/gotham-rs/gotham/tree/master/examples" alt="Example application of GitHub">Examples</a>
                     </li>
                     <li>
-                      <a href="https://github.com/gotham-rs/policies" alt="Gotham policies on GitHub">Policies</a>
+                      <a href="https://github.com/gotham-rs/gotham/blob/master/CONDUCT.md" alt="Code of Conduct">Code of Conduct</a>
                     </li>
                   </ul>
                 </div>


### PR DESCRIPTION
This PR changes the URLs for examples and the Code of Conduct, both of which were linked to previous GitHub projects that have since been migrated to the main repository.