### PR TITLE
Remove unused futures crate from examples

### DIFF
--- a/_includes/example_1
+++ b/_includes/example_1
@@ -1,6 +1,5 @@
 //! A Hello World example application for working with Gotham.
 
-extern crate futures;
 extern crate gotham;
 extern crate hyper;
 extern crate mime;

--- a/_includes/example_2
+++ b/_includes/example_2
@@ -1,7 +1,6 @@
 //! An example of the Gotham web framework `Router` that shows how to associate multiple handlers
 //! to a single path.
 
-extern crate futures;
 extern crate gotham;
 extern crate hyper;
 extern crate mime;

--- a/_includes/example_3
+++ b/_includes/example_3
@@ -1,7 +1,6 @@
 //! An introduction to extracting query string name/value pairs, in a type safe way, with the
 //! Gotham web framework
 
-extern crate futures;
 extern crate gotham;
 #[macro_use]
 extern crate gotham_derive;


### PR DESCRIPTION
Relates to https://github.com/gotham-rs/gotham/pull/211 in that some of the examples use the `futures` crate when it's really not necessary and is a small misdirection which can cause confusion for beginners. 