### PR TITLE
Use simplified create_response API

### DIFF
--- a/_posts/2018-09-29-gotham-0.3.md
+++ b/_posts/2018-09-29-gotham-0.3.md
@@ -183,8 +183,7 @@ fn say_hello(state: State) -> (State, Response<Body>) {
     };
 
     // create the response
-    let body = (message, mime::TEXT_PLAIN);
-    let res = create_response(&state, StatusCode::OK, body);
+    let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, message);
 
     // done!
     (state, res)


### PR DESCRIPTION
Replaces body, content-type as tuple in create_response. Resolves [@gotham-rs/gotham-rs#303](https://github.com/gotham-rs/gotham/issues/303).