### PR TITLE
Correct example_1 to work on gotham 0.4

### DIFF
--- a/_includes/example_1
+++ b/_includes/example_1
@@ -1,6 +1,7 @@
 //! A Hello World example application for working with Gotham.
 
 extern crate gotham;
+extern crate http;
 
 use gotham::state::State;
 
@@ -26,6 +27,7 @@ pub fn main() {
 mod tests {
     use super::*;
     use gotham::test::TestServer;
+    use http::status::StatusCode;
 
     #[test]
     fn receive_hello_world_response() {
@@ -36,6 +38,7 @@ mod tests {
             .perform()
             .unwrap();
 
+        // requires http 0.1.21
         assert_eq!(response.status(), StatusCode::Ok);
 
         let body = response.read_body().unwrap();


### PR DESCRIPTION
This code snippet didn't work otherwise because `StatusCode` was not in scope.

Also `http` 0.2.0 changes the APIs a little bit to make the example incompatible