### PR TITLE
Remove static lifetime

### DIFF
--- a/_includes/example_1
+++ b/_includes/example_1
@@ -4,7 +4,7 @@ extern crate gotham;
 
 use gotham::state::State;
 
-const HELLO_WORLD: &'static str = "Hello World!";
+const HELLO_WORLD: &str = "Hello World!";
 
 /// Create a `Handler` which is invoked when responding to a `Request`.
 ///


### PR DESCRIPTION
It's rust 2018, we dont need it anymore :)